### PR TITLE
Fix responsive demo pages

### DIFF
--- a/Demo/form1.html
+++ b/Demo/form1.html
@@ -1,7 +1,8 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <title>Demonstrating Responsiveness</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <link href="css/bootstrap-theme.css" rel="stylesheet" />
     <link href="css/bootstrap-theme.min.css" rel="stylesheet" />

--- a/Demo/form2.html
+++ b/Demo/form2.html
@@ -1,7 +1,8 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <title>Demonstrating Responsiveness</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <link href="css/bootstrap-theme.css" rel="stylesheet" />
     <link href="css/bootstrap-theme.min.css" rel="stylesheet" />

--- a/Demo/form3.html
+++ b/Demo/form3.html
@@ -1,7 +1,8 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <title>Demonstrating Responsiveness</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <link href="css/bootstrap-theme.css" rel="stylesheet" />
     <link href="css/bootstrap-theme.min.css" rel="stylesheet" />

--- a/Demo/form4.html
+++ b/Demo/form4.html
@@ -1,7 +1,8 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <title>Demonstrating Responsiveness</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <link href="css/bootstrap-theme.css" rel="stylesheet" />
     <link href="css/bootstrap-theme.min.css" rel="stylesheet" />

--- a/Demo/form5.html
+++ b/Demo/form5.html
@@ -1,7 +1,8 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <title>Demonstrating Responsiveness</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <link href="css/bootstrap-theme.css" rel="stylesheet" />
     <link href="css/bootstrap-theme.min.css" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- add missing viewport meta tag so the demo pages scale correctly on mobile devices
- strip BOM characters that were appearing at the start of each HTML file

## Testing
- `git diff HEAD~1 HEAD --stat`